### PR TITLE
Add `buildFromCargo` nix package

### DIFF
--- a/src/pages/installation-scripts.mdx
+++ b/src/pages/installation-scripts.mdx
@@ -25,8 +25,65 @@ import CodeBlock from '@theme/CodeBlock';
 ```bash
 powershell -c "irm https://raw.githubusercontent.com/dora-rs/dora/main/install.ps1 | iex"
 ```
-- If you use VSCode, make sure to restart VSCode for the change to happen.
+  - If you use VSCode, make sure to restart VSCode for the change to happen.
 
+  </TabItem>
+  <TabItem value="nix" label="Nix Package">
+  - Create a file with this content:
+```nix
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+pkgs.rustPlatform.buildRustPackage rec {
+  pname = "dora-cli";
+  version = "0.3.6";
+
+  src = pkgs.fetchFromGitHub {
+    owner = "dora-rs";
+    repo = "dora";
+    rev = "v${version}";
+    hash = "sha256-YwEqwA7Eqz7ZJYFfKoPTWkmgsudKpoATcFE6OOwxpbU=";
+  };
+
+  cargoHash = "sha256-AkungKYGHMK/tUfzh0d88zRRkQfshus7xOHzdtYAT/I=";
+  nativeBuildInputs = [pkgs.pkg-config];
+  buildInputs = [pkgs.openssl];
+  OPENSSL_NO_VENDOR = 1;
+  buildPhase = ''
+    cargo build --release -p dora-cli
+  '';
+  installPhase = ''
+    mkdir -p $out/bin
+    cp target/release/dora $out/bin
+  '';
+  doCheck = false;
+
+  meta = {
+    description = "Making robotic applications fast and simple!";
+    homepage = "https://dora-rs.ai/";
+    changelog = "https://github.com/dora-rs/dora/blob/main/Changelog.md";
+    mainProgram = "dora";
+    license = lib.licenses.asl20;
+  };
+}
+```
+  - And import it, for example, with home-manager:
+```nix
+{
+  config,
+  pkgs,
+  ...
+}: {
+  # snip
+  home.packages = with pkgs; [
+    # snip
+    (import ./dora.nix {inherit config pkgs lib ;})
+  ];
+}
+```
   </TabItem>
   <TabItem value="cargo" label="Cargo">
 

--- a/src/pages/installation-scripts.mdx
+++ b/src/pages/installation-scripts.mdx
@@ -28,61 +28,59 @@ powershell -c "irm https://raw.githubusercontent.com/dora-rs/dora/main/install.p
   - If you use VSCode, make sure to restart VSCode for the change to happen.
 
   </TabItem>
-  <TabItem value="nix" label="Nix Package">
-  - Create a file with this content:
+  <TabItem value="nix" label="Nix[OS]">
+  - To make a base dev-shell (Recommended):
 ```nix
 {
-  lib,
-  config,
-  pkgs,
-  ...
-}:
-pkgs.rustPlatform.buildRustPackage rec {
-  pname = "dora-cli";
-  version = "0.3.6";
-
-  src = pkgs.fetchFromGitHub {
-    owner = "dora-rs";
-    repo = "dora";
-    rev = "v${version}";
-    hash = "sha256-YwEqwA7Eqz7ZJYFfKoPTWkmgsudKpoATcFE6OOwxpbU=";
+  description = "A base dev-shell flake";
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    dora-rs = {
+      url = "github:dora-rs/dora";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
-
-  cargoHash = "sha256-AkungKYGHMK/tUfzh0d88zRRkQfshus7xOHzdtYAT/I=";
-  nativeBuildInputs = [pkgs.pkg-config];
-  buildInputs = [pkgs.openssl];
-  OPENSSL_NO_VENDOR = 1;
-  buildPhase = ''
-    cargo build --release -p dora-cli
-  '';
-  installPhase = ''
-    mkdir -p $out/bin
-    cp target/release/dora $out/bin
-  '';
-  doCheck = false;
-
-  meta = {
-    description = "Making robotic applications fast and simple!";
-    homepage = "https://dora-rs.ai/";
-    changelog = "https://github.com/dora-rs/dora/blob/main/Changelog.md";
-    mainProgram = "dora";
-    license = lib.licenses.asl20;
+  outputs = {
+    self,
+    nixpkgs,
+    dora-rs,
+  }: let
+    system = "x86_64-linux";
+    #        ↑ Swap it for your system as needed
+    pkgs = nixpkgs.legacyPackages.${system};
+  in {
+    devShells.${system}.default = pkgs.mkShell {
+      buildInputs = [
+        dora-rs.packages.${system}.dora-cli
+      ];
+    };
   };
 }
 ```
-  - And import it, for example, with home-manager:
+  - To add to a system-config flake:
+  1. First, add this to your inputs
+```nix
+    dora-rs = {
+      url = "github:dora-rs/dora";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+```
+  2. ...and add to your packages array. E.g. adding to your home-manager config:
 ```nix
 {
+  inputs,
   config,
   pkgs,
   ...
 }: {
-  # snip
   home.packages = with pkgs; [
-    # snip
-    (import ./dora.nix {inherit config pkgs lib ;})
+    inputs.dora-rs.packages.x86_64-linux.dora-cli
   ];
 }
+```
+  - To install ([not recommended](https://stop-using-nix-env.privatevoid.net/))
+```
+nix-env --install "github:dora-rs/dora"
 ```
   </TabItem>
   <TabItem value="cargo" label="Cargo">


### PR DESCRIPTION
This documents how those using `nix`, or are in `NixOS` can install the dora CLI app.

This is a best effort, and I can't say whether or not someone that is experienced with nix would ping something in this PR. It works for me, and would like to offer to upstream the fruits of my efforts.

Hold off on doing anything until this is resolved:

https://github.com/dora-rs/dora/pull/685