### PR TITLE
docs: replace deprecated Jaeger tracing with SigNoz/OTLP setup

### DIFF
--- a/docs/guides/Debugging/tracing.md
+++ b/docs/guides/Debugging/tracing.md
@@ -1,17 +1,34 @@
 # Tracing
 
-You can easily integrate jaeger tracing by providing `DORA_JAEGER_TRACING` environment variable
+Dora supports distributed tracing via OpenTelemetry (OTLP). The previous Jaeger integration (DORA_JAEGER_TRACING) has been removed as of recent versions. Use the OTLP endpoint instead.
+
+## Setup with SigNoz
+
+[SigNoz](https://signoz.io) is the recommended open-source observability backend for dora tracing.
+
+### 1. Start SigNoz
 
 ```bash
-export DORA_JAEGER_TRACING=172.17.0.1:6831 # Jaeger backend address
-dora up
-dora start dataflow.yml
+git clone -b main https://github.com/SigNoz/signoz.git
+cd signoz/deploy
+docker compose -f docker/docker-compose.yaml up -d
 ```
 
-To start a jaeger backend, you can use:
+SigNoz UI will be available at: http://localhost:8080
+
+### 2. Run your dataflow with tracing
 
 ```bash
-docker run -d -p6831:6831/udp -p6832:6832/udp -p16686:16686 jaegertracing/all-in-one:latest
+export DORA_OTLP_ENDPOINT=http://localhost:4317
+dora run dataflow.yaml --uv
 ```
 
-You can then check jaeger UI: http://localhost:16686/
+### 3. View traces
+
+Open SigNoz at http://localhost:8080 and navigate to Services or Traces Explorer to inspect your dataflow telemetry.
+
+## Notes
+
+- DORA_JAEGER_TRACING is no longer supported and has been removed from the codebase.
+- The OTLP collector in SigNoz listens on port 4317 by default.
+- Metrics ingestion is active when the endpoint is correctly configured.

--- a/docs/guides/Debugging/tracing.md
+++ b/docs/guides/Debugging/tracing.md
@@ -9,7 +9,7 @@ Dora supports distributed tracing via OpenTelemetry (OTLP). The previous Jaeger 
 ### 1. Start SigNoz
 
 ```bash
-git clone -b main https://github.com/SigNoz/signoz.git
+git clone --branch v0.115.0 --depth 1 https://github.com/SigNoz/signoz.git
 cd signoz/deploy
 docker compose -f docker/docker-compose.yaml up -d
 ```


### PR DESCRIPTION
Fixes #1313 (reported in dora-rs/dora)

The previous tracing guide referenced DORA_JAEGER_TRACING which has been fully removed from the dora codebase (see dora-rs/dora#1397). This PR updates the documentation to reflect the current recommended setup using SigNoz and OTLP.

Changes:
- Removed deprecated Jaeger instructions
- Added SigNoz setup steps (validated locally)
- Updated environment variable to DORA_OTLP_ENDPOINT
- Added notes clarifying deprecation status

Tested on: Ubuntu 24.04 (WSL2), dora-cli 0.4.1, SigNoz v0.115.0