### PR TITLE
fix(book): repoint /book/ links to live guide, fixes #2010

### DIFF
--- a/src/data/book-chapters.json
+++ b/src/data/book-chapters.json
@@ -11,7 +11,7 @@
     "chapters": [
       { "title": "Architecture", "description": "CLI, Coordinator, Daemon, and Node layers explained", "href": "/book/concepts/architecture" },
       { "title": "Dataflow YAML", "description": "Define pipelines as directed graphs with typed inputs and outputs", "href": "/book/concepts/dataflow-yaml" },
-      { "title": "Type Annotations", "description": "Static type checking for dataflow connections", "href": "/book/concepts/type-annotations" },
+      { "title": "Type Annotations", "description": "Static type checking for dataflow connections", "href": "/book/concepts/types" },
       { "title": "Modules", "description": "Compose reusable sub-graphs as standalone YAML files", "href": "/book/concepts/modules" },
       { "title": "Communication Patterns", "description": "Topic, Service, Action, and Streaming patterns", "href": "/book/concepts/patterns" }
     ]

--- a/src/pages/book.astro
+++ b/src/pages/book.astro
@@ -5,7 +5,7 @@ import Container from 'components/layout/Container.astro';
 import Button from 'components/ui/Button.astro';
 import chapters from 'data/book-chapters.json';
 
-const bookUrl = 'https://dora-rs.github.io/dora-book/';
+const bookUrl = 'https://dora-rs.ai/dora/';
 ---
 
 <Layout


### PR DESCRIPTION
## Problem

Every chapter link on [dora-rs.ai/book/](https://dora-rs.ai/book/) is broken (404) — reported in dora-rs/dora#2010. The landing page hardcoded `bookUrl = 'https://dora-rs.github.io/dora-book/'`, but that path no longer exists: the user guide was migrated into the main repo at [`guide/`](https://github.com/dora-rs/dora/tree/main/guide) (mdBook) and now deploys to **https://dora-rs.ai/dora/**.

## Fix

- `src/pages/book.astro` — `bookUrl` → `https://dora-rs.ai/dora/` (fixes the chapter grid + the "Read the Book" button).
- `src/data/book-chapters.json` — rename the one slug that changed in the new guide: `concepts/type-annotations` → `concepts/types`.

GitHub Pages serves the extensionless URLs (`/dora/concepts/architecture` → 200), so no `.html` suffix is needed.

## Verification

All 23 chapter URLs + the index + the "Read the Book" button resolve `200` under the new base (probed live against `https://dora-rs.ai/dora/`). JSON validated.

Targets `adora-website` (the branch the live Astro site deploys from).

Closes dora-rs/dora#2010

🤖 Generated with [Claude Code](https://claude.com/claude-code)