### PR TITLE
ci(deploy): trigger Pages deploy on main (was adora-website)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [adora-website]
+    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
## What

Point the GitHub Pages deploy trigger at `main` instead of `adora-website`.

## Why

The live Astro site branch `adora-website` was renamed to `main` (now the default branch), and the old Docusaurus `main` was renamed to `legacy-docusaurus`. Without this change, pushes to the new default branch would not publish the site.

## Note

Once merged, the new `main` is **unprotected** — branch protection stayed with the renamed old branch. Re-adding a protection rule on `main` is recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
