### PR TITLE
fix(quickstart): use runnable dora run flow + real node-hub paths

### DIFF
--- a/src/components/sections/QuickStart.astro
+++ b/src/components/sections/QuickStart.astro
@@ -9,23 +9,31 @@ cargo install dora-cli
 <span class="text-neutral-2"># Create a dataflow</span>
 cat > dataflow.yml << <span class="text-neutral-1">'EOF'</span>
 nodes:
-  - id: webcam
-    path: dora-hub/webcam
-    outputs: [image]
-  - id: detector
-    path: dora-hub/yolov8
+  - id: camera
+    build: pip install opencv-video-capture
+    path: opencv-video-capture
     inputs:
-      image: webcam/image
+      tick: dora/timer/millis/20
+    outputs: [image]
+    env:
+      CAPTURE_PATH: 0
+  - id: object-detection
+    build: pip install dora-yolo
+    path: dora-yolo
+    inputs:
+      image: camera/image
     outputs: [bbox]
   - id: plot
-    path: dora-hub/opencv-plot
+    build: pip install dora-rerun
+    path: dora-rerun
     inputs:
-      image: webcam/image
-      bbox: detector/bbox
+      image: camera/image
+      boxes2d: object-detection/bbox
 <span class="text-neutral-1">EOF</span>
 
-<span class="text-neutral-2"># Run it</span>
-dora start dataflow.yml`;
+<span class="text-neutral-2"># Build the nodes, then run locally</span>
+dora build dataflow.yml
+dora run dataflow.yml`;
 ---
 
 <Section id="quickstart" background="secondary" padY="lg">

--- a/src/pages/zh-cn/index.astro
+++ b/src/pages/zh-cn/index.astro
@@ -601,8 +601,8 @@ const stats = [
         <pre class="font-mono text-[15px] leading-relaxed text-neutral-2"><code><span class="text-neutral-1"># 安装 dora CLI</span>
 cargo install dora-cli
 
-<span class="text-neutral-1"># 启动数据流</span>
-dora start dataflow.yml
+<span class="text-neutral-1"># 本地运行数据流</span>
+dora run dataflow.yml
 
 <span class="text-neutral-1"># 查看状态</span>
 dora list


### PR DESCRIPTION
## Problem

The homepage QuickStart was not runnable as written:

1. **`dora start dataflow.yml`** fails for a new user — `dora start` requires a running coordinator/daemon (`dora up` first). The canonical local first-run command is **`dora run`**.
2. The example used **node paths that don't exist** — `dora-hub/webcam`, `dora-hub/yolov8`, `dora-hub/opencv-plot`. Node-hub nodes are pip packages referenced by their entry-point name with a `build:` line.

## Fix

Replace the example with the [README's authoritative pipeline](https://github.com/dora-rs/dora#dataflow-configuration) — real node-hub packages with `build:` lines and the correct command sequence:

- `opencv-video-capture`, `dora-yolo`, `dora-rerun` (each with `build: pip install …`)
- `dora build dataflow.yml` then `dora run dataflow.yml`

Also fixes the zh-CN homepage the same way (`dora start dataflow.yml` → `dora run dataflow.yml`).

## Verification

- `astro build` passes.
- Rendered `dist/index.html`: 6 hub-node mentions, 1 `dora run dataflow.yml`, **0** stale `dora-hub/` or `dora start dataflow.yml`.
- Rendered `dist/zh-cn/index.html`: 1 `dora run`, **0** stale `dora start`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
