### PR TITLE
fix(site): anchor header-offset + zh-CN nav/book link bugs

### DIFF
--- a/src/pages/zh-cn/book.astro
+++ b/src/pages/zh-cn/book.astro
@@ -3,6 +3,8 @@ import Layout from 'layouts/Layout.astro';
 import Section from 'components/layout/Section.astro';
 import Container from 'components/layout/Container.astro';
 import chapters from 'data/book-chapters.json';
+
+const bookUrl = 'https://dora-rs.ai/dora/zh-CN/';
 ---
 
 <Layout
@@ -35,7 +37,7 @@ import chapters from 'data/book-chapters.json';
             <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
               {group.chapters.map((ch) => (
                 <a
-                  href={ch.href}
+                  href={bookUrl + ch.href.replace('/book/', '')}
                   class="group block rounded-lg border border-surface-3 bg-surface-1 p-5 transition-all duration-300 hover:border-accent hover:bg-surface-2"
                 >
                   <h3 class="text-[16px] font-normal text-text-bright transition-colors group-hover:text-accent">

--- a/src/pages/zh-cn/index.astro
+++ b/src/pages/zh-cn/index.astro
@@ -179,7 +179,7 @@ const stats = [
   <!-- ════════════════════════════════════════════════════════════════════
        Features
        ════════════════════════════════════════════════════════════════════ -->
-  <Section padY="lg">
+  <Section id="features" padY="lg">
     <Container>
       <div class="mb-12 lg:mb-16">
         <p class="font-mono text-[16px] uppercase tracking-[0.08em] text-neutral-2">核心能力</p>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -110,6 +110,8 @@ html[data-theme="light"] {
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     scroll-behavior: smooth;
+    /* Offset anchor targets so section headings clear the fixed header (~69px) */
+    scroll-padding-top: 84px;
     transition: background-color 0.3s ease, color 0.3s ease;
   }
 


### PR DESCRIPTION
## Audit

Ran a headless (Playwright) + static audit across all 6 built pages (EN/zh-CN × home/comparison/book). Checked: in-page anchor navigation, internal link resolution, external links, console errors, failed requests, broken images.

**Clean:** 0 console errors, 0 failed requests, 0 broken images on every page; all internal page links and external links (GitHub, docs.rs, Discord) resolve.

**Three bugs found and fixed:**

### 1. Anchor links land under the sticky header (the reported "Architecture does nothing")
The header is `fixed` (~69px) but there was no `scroll-padding-top`. Clicking any nav anchor *did* scroll, but the target heading landed at `top: 0` — hidden behind the header — so it looked like nothing happened. Added `scroll-padding-top: 84px` on `html`. Fixes all anchors site-wide (EN + zh-CN).

### 2. zh-CN homepage `特性` (#features) nav link was dead
The zh-CN features section had no `id`, so `#features` had no target (`scrollY 0→0`). Added `id="features"`.

### 3. zh-CN book page links 404
`/zh-cn/book/` chapter links pointed at root-relative `/book/<slug>` (404). PR #64 fixed only the EN `book.astro`; applied the same fix to the zh-CN page, pointing at the zh-CN guide (`https://dora-rs.ai/dora/zh-CN/`). Verified those slugs return 200.

## Verification

Rebuilt and re-ran the headless audit: all anchors scroll on both homepages, zh-CN book links resolve to the zh-CN guide, 0 errors across all pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
