### PR TITLE
chore(content): align website with dora main (record fmt, counts, bridges, chapters)

### DIFF
--- a/src/components/sections/Comparison.astro
+++ b/src/components/sections/Comparison.astro
@@ -6,7 +6,7 @@ const rows = [
   { dim: 'Latency (SHM)', dora1: '~500us p50', dora0: '~500us p50', ros2: '1-10ms' },
   { dim: 'Comm patterns', dora1: '4 (Topic/Service/Action/Stream)', dora0: '1 (Topic)', ros2: '4' },
   { dim: 'Fault tolerance', dora1: 'Built-in restart policies', dora0: 'None', ros2: 'Basic' },
-  { dim: 'Record/Replay', dora1: 'Built-in (.dora)', dora0: 'None', ros2: 'rosbag' },
+  { dim: 'Record/Replay', dora1: 'Built-in (.drec)', dora0: 'None', ros2: 'rosbag' },
   { dim: 'Cluster management', dora1: 'SSH + labels', dora0: 'None', ros2: 'Manual' },
   { dim: 'Dynamic topology', dora1: 'Yes', dora0: 'No', ros2: 'Partial' },
   { dim: 'Observability', dora1: 'OpenTelemetry', dora0: 'Basic logs', ros2: 'ROS2 logging' },

--- a/src/data/book-chapters.json
+++ b/src/data/book-chapters.json
@@ -3,7 +3,7 @@
     "section": "Getting Started",
     "chapters": [
       { "title": "Installation", "description": "Install the dora CLI and runtime on Linux, macOS, or Windows", "href": "/book/getting-started/installation" },
-      { "title": "Quickstart", "description": "Build and run your first dataflow in under 5 minutes", "href": "/book/getting-started/quickstart" }
+      { "title": "Quick Start", "description": "Build and run your first dataflow in under 5 minutes", "href": "/book/getting-started/quickstart" }
     ]
   },
   {
@@ -33,7 +33,7 @@
       { "title": "Debugging", "description": "Topic inspection, trace viewing, and resource monitoring", "href": "/book/operations/debugging" },
       { "title": "Fault Tolerance", "description": "Restart policies, health checks, and circuit breakers", "href": "/book/operations/fault-tolerance" },
       { "title": "Distributed Deployment", "description": "Multi-machine clusters with SSH and label scheduling", "href": "/book/operations/distributed" },
-      { "title": "Performance Tuning", "description": "Queue sizes, shared memory thresholds, and Arrow optimization", "href": "/book/operations/performance" },
+      { "title": "Performance", "description": "Queue sizes, shared memory thresholds, and Arrow optimization", "href": "/book/operations/performance" },
       { "title": "Real-Time Tuning", "description": "SCHED_FIFO, mlockall, CPU affinity, and kernel parameters", "href": "/book/operations/realtime-tuning" },
       { "title": "Dynamic Topology", "description": "Add, remove, connect, and disconnect nodes at runtime", "href": "/book/operations/dynamic-topology" }
     ]
@@ -42,8 +42,8 @@
     "section": "Advanced",
     "chapters": [
       { "title": "ROS2 Bridge", "description": "Bidirectional interop with ROS2 topics, services, and actions", "href": "/book/advanced/ros2-bridge" },
-      { "title": "WebSocket Control", "description": "Programmatic control via the WebSocket API", "href": "/book/advanced/ws-control" },
-      { "title": "WebSocket Topics", "description": "Stream topic data over WebSocket for web UIs", "href": "/book/advanced/ws-topic" }
+      { "title": "WebSocket Control Plane", "description": "Programmatic control via the WebSocket API", "href": "/book/advanced/ws-control" },
+      { "title": "WebSocket Topic Data", "description": "Stream topic data over WebSocket for web UIs", "href": "/book/advanced/ws-topic" }
     ]
   },
   {

--- a/src/data/features.json
+++ b/src/data/features.json
@@ -25,7 +25,7 @@
   },
   {
     "title": "Record & Replay",
-    "description": "Capture dataflow messages to .dora files. Replay offline at any speed with node substitution for regression testing and offline debugging.",
+    "description": "Capture dataflow messages to .drec files. Replay offline at any speed with node substitution for regression testing and offline debugging.",
     "stat": null,
     "statLabel": null
   },
@@ -50,6 +50,12 @@
   {
     "title": "Agentic Engineering",
     "description": "Built and maintained with autonomous AI agents driving code generation, reviews, refactoring, testing, and commits.",
+    "stat": null,
+    "statLabel": null
+  },
+  {
+    "title": "ROS2 & MAVLink Bridges",
+    "description": "Bidirectional ROS2 bridge (experimental) with Arrow-native conversion and QoS mapping, plus a MAVLink 2 bridge (TCP/UDP/serial) for drone/robotics interop.",
     "stat": null,
     "statLabel": null
   }

--- a/src/data/zh-cn/features.json
+++ b/src/data/zh-cn/features.json
@@ -25,7 +25,7 @@
   },
   {
     "title": "录制与回放",
-    "description": "将数据流消息录制到 .dora 文件。以任意速度离线回放，支持节点替换，用于回归测试和离线调试。",
+    "description": "将数据流消息录制到 .drec 文件。以任意速度离线回放，支持节点替换，用于回归测试和离线调试。",
     "stat": null,
     "statLabel": null
   },
@@ -49,8 +49,14 @@
   },
   {
     "title": "智能体工程",
-    "description": "由自主 AI 智能体驱动代码生成、审查、重构、测试和提交。772 个源文件，持续增长中。",
-    "stat": "772",
-    "statLabel": "源文件"
+    "description": "由自主 AI 智能体驱动代码生成、审查、重构、测试和提交。",
+    "stat": null,
+    "statLabel": null
+  },
+  {
+    "title": "ROS2 与 MAVLink 桥接",
+    "description": "双向 ROS2 桥接（实验性），支持 Arrow 原生转换和 QoS 映射；以及 MAVLink 2 桥接（TCP/UDP/串口），用于无人机/机器人互操作。",
+    "stat": null,
+    "statLabel": null
   }
 ]

--- a/src/data/zh-cn/stats.json
+++ b/src/data/zh-cn/stats.json
@@ -2,6 +2,5 @@
   { "value": "10-17x", "label": "快于 ROS2" },
   { "value": "4", "label": "通信模式" },
   { "value": "4", "label": "编程语言" },
-  { "value": "772", "label": "源文件" },
   { "value": "0", "label": "拷贝开销" }
 ]

--- a/src/pages/comparison.astro
+++ b/src/pages/comparison.astro
@@ -12,7 +12,7 @@ const featureMatrix = [
   { dim: 'Latency (SHM path)', dora1: '~500us p50', dora0: '~500us p50', ros2: '1-10ms' },
   { dim: 'Copy overhead', dora1: 'Zero (Apache Arrow)', dora0: 'Zero (Apache Arrow)', ros2: 'CDR serialization' },
   { dim: 'Fault tolerance', dora1: 'Built-in (restart policies, health checks, circuit breakers)', dora0: 'None', ros2: 'Basic lifecycle' },
-  { dim: 'Record / Replay', dora1: 'Built-in (.dora files)', dora0: 'None', ros2: 'rosbag2' },
+  { dim: 'Record / Replay', dora1: 'Built-in (.drec files)', dora0: 'None', ros2: 'rosbag2' },
   { dim: 'Dynamic topology', dora1: 'Yes (add/remove/connect/disconnect at runtime)', dora0: 'No', ros2: 'Partial (lifecycle nodes)' },
   { dim: 'Cluster management', dora1: 'Built-in SSH clusters with label scheduling', dora0: 'None', ros2: 'Manual or external tools' },
   { dim: 'Observability', dora1: 'OpenTelemetry (logs, metrics, traces)', dora0: 'Basic logging', ros2: 'ROS2 logging + third-party' },
@@ -27,7 +27,7 @@ const featureMatrix = [
   { dim: 'Python CLI API', dora1: 'PyO3 native bindings', dora0: 'None', ros2: 'rclpy' },
   { dim: 'Coordinator HA', dora1: 'Persistent redb state + daemon reconnect', dora0: 'None', ros2: 'N/A (no coordinator)' },
   { dim: 'Source files', dora1: '772', dora0: '488', ros2: '~50,000+' },
-  { dim: 'Examples', dora1: '37', dora0: '20', ros2: 'Hundreds (community)' },
+  { dim: 'Examples', dora1: '45', dora0: '20', ros2: 'Hundreds (community)' },
   { dim: 'CI templates', dora1: 'Reusable downstream CI workflows', dora0: 'None', ros2: 'N/A' },
 ];
 
@@ -36,11 +36,11 @@ const cliComparison = [
   { command: 'Stop dataflow', dora1: 'dora stop', dora0: 'dora destroy' },
   { command: 'View logs', dora1: 'dora logs --node webcam', dora0: '(stdout only)' },
   { command: 'Record messages', dora1: 'dora record', dora0: '(not available)' },
-  { command: 'Replay recording', dora1: 'dora replay recording.dora', dora0: '(not available)' },
+  { command: 'Replay recording', dora1: 'dora replay recording.drec', dora0: '(not available)' },
   { command: 'Live topic data', dora1: 'dora topic echo webcam/image', dora0: '(not available)' },
   { command: 'Frequency monitor', dora1: 'dora topic hz webcam/image', dora0: '(not available)' },
   { command: 'Resource monitor', dora1: 'dora top', dora0: '(not available)' },
-  { command: 'Add node at runtime', dora1: 'dora node add --path ./detector', dora0: '(not available)' },
+  { command: 'Add node at runtime', dora1: 'dora node add --from-yaml node.yml', dora0: '(not available)' },
   { command: 'Cluster deploy', dora1: 'dora cluster up', dora0: '(not available)' },
   { command: 'Validate dataflow', dora1: 'dora validate dataflow.yml', dora0: '(not available)' },
   { command: 'View traces', dora1: 'dora trace list', dora0: '(not available)' },
@@ -261,7 +261,7 @@ node.send_service_response("response", metadata.parameters, result)`,
         </div>
         <div class="rounded-lg border border-surface-3 bg-surface-1 p-5">
           <h3 class="text-[16px] text-accent">Record & Replay</h3>
-          <p class="mt-2 text-[16px] text-neutral-2">Capture all messages to .dora files. Replay at any speed with node substitution for regression testing.</p>
+          <p class="mt-2 text-[16px] text-neutral-2">Capture all messages to .drec files. Replay at any speed with node substitution for regression testing.</p>
         </div>
         <div class="rounded-lg border border-surface-3 bg-surface-1 p-5">
           <h3 class="text-[16px] text-accent">Cluster Management</h3>

--- a/src/pages/zh-cn/comparison.astro
+++ b/src/pages/zh-cn/comparison.astro
@@ -11,7 +11,7 @@ const featureMatrix = [
   { dim: '延迟 (SHM)', dora1: '~500us p50', dora0: '~500us p50', ros2: '1-10ms' },
   { dim: '拷贝开销', dora1: '零 (Apache Arrow)', dora0: '零 (Apache Arrow)', ros2: 'CDR 序列化' },
   { dim: '容错', dora1: '内置（重启策略、健康检查、熔断器）', dora0: '无', ros2: '基础生命周期' },
-  { dim: '录制/回放', dora1: '内置 (.dora 文件)', dora0: '无', ros2: 'rosbag2' },
+  { dim: '录制/回放', dora1: '内置 (.drec 文件)', dora0: '无', ros2: 'rosbag2' },
   { dim: '动态拓扑', dora1: '支持（运行时添加/移除/连接/断开）', dora0: '不支持', ros2: '部分（生命周期节点）' },
   { dim: '集群管理', dora1: '内置 SSH 集群 + 标签调度', dora0: '无', ros2: '手动或外部工具' },
   { dim: '可观测性', dora1: 'OpenTelemetry（日志、指标、追踪）', dora0: '基础日志', ros2: 'ROS2 日志 + 第三方' },

--- a/src/pages/zh-cn/index.astro
+++ b/src/pages/zh-cn/index.astro
@@ -34,7 +34,7 @@ const comparisonRows = [
   { dim: '延迟 (SHM)', dora1: '~500us p50', dora0: '~500us p50', ros2: '1-10ms' },
   { dim: '通信模式', dora1: '4 (Topic/Service/Action/Stream)', dora0: '1 (Topic)', ros2: '4' },
   { dim: '容错机制', dora1: '内置重启策略', dora0: '无', ros2: '基础' },
-  { dim: '录制/回放', dora1: '内置 (.dora)', dora0: '无', ros2: 'rosbag' },
+  { dim: '录制/回放', dora1: '内置 (.drec)', dora0: '无', ros2: 'rosbag' },
   { dim: '集群管理', dora1: 'SSH + 标签', dora0: '无', ros2: '手动' },
   { dim: '动态拓扑', dora1: '支持', dora0: '不支持', ros2: '部分支持' },
   { dim: '可观测性', dora1: 'OpenTelemetry', dora0: '基础日志', ros2: 'ROS2 日志' },


### PR DESCRIPTION
## What

A multi-agent audit aligned the site's content against the **dora repo `main` branch** (README, `docs/cli.md`, `guide/SUMMARY.md`, `examples/`, `node-hub/`). Only **verified factual** corrections were applied — no marketing rewrites — and EN + zh-CN were kept in parity.

## Changes

- **Record/replay extension `.dora` → `.drec`** everywhere. dora renamed the recording format; confirmed in `docs/cli.md`, `docs/architecture.md`, and the `dora-recording` lib. (6 files)
- **CLI fix:** `dora node add --path ./detector` → `--from-yaml node.yml` (correct flag per `docs/cli.md`).
- **Examples count 37 → 45** (actual `examples/` dir count on `main`).
- **New "ROS2 & MAVLink Bridges" feature card** (both locales) — softened to "experimental" with **no** unverified ROS2 distro floor (the audit agent's original "≥ Foxy" wasn't supported by any dora doc, so I removed it).
- **book-chapters.json titles** aligned to `guide/SUMMARY.md` (Quick Start, Performance, WebSocket Control Plane, WebSocket Topic Data).
- **Dropped the hard-coded "772 source files"** stat (unverifiable snapshot that only drifts).

## Verification

- `astro build` passes.
- Full **headless Playwright** pass on all 6 pages (EN/zh × home/comparison/book): all nav anchors scroll, **0** console errors / failed requests / broken images.
- All changed JSON valid; EN/zh feature-card counts in parity (10 each).

## Deferred for your decision (not auto-applied)

1. **FAQ "Is dora 1.0 production-ready? Yes."** — dora main is `1.0.0-rc1` (release candidate) and per the repo, running-dataflow reclaim across coordinator restart is partial. Consider qualifying the answer (RC stage).
2. **`dora topic echo/hz`** comparison cells omit the required `-d <dataflow>` flag (illustrative cells, still readable).
3. **"772 / 488 source files" row** in the comparison tables — left intact (it's a meaningful lean-vs-ROS2 point) but it's a drift-prone hard-coded snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
