### PR TITLE
fix(nav): make section-anchor links work from sub-pages

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -6,18 +6,22 @@ const isZhCn = Astro.url.pathname.includes('/zh-cn');
 const langSwitchHref = isZhCn ? `${base}/` : `${base}/zh-cn/`;
 const langSwitchLabel = isZhCn ? 'EN' : 'CN';
 
+// Section anchors live on the home page; prefix with the home path so the
+// links also work from sub-pages (/comparison, /book) instead of resolving to
+// a non-existent anchor on the current page.
+const home = isZhCn ? `${base}/zh-cn/` : `${base}/`;
 const navLinks = isZhCn ? [
-  { text: '特性', href: '#features' },
-  { text: '架构', href: '#architecture' },
-  { text: '性能', href: '#performance' },
+  { text: '特性', href: `${home}#features` },
+  { text: '架构', href: `${home}#architecture` },
+  { text: '性能', href: `${home}#performance` },
   { text: '对比', href: `${base}/zh-cn/comparison` },
-  { text: '快速开始', href: '#quickstart' },
+  { text: '快速开始', href: `${home}#quickstart` },
 ] : [
-  { text: 'Features', href: '#features' },
-  { text: 'Architecture', href: '#architecture' },
-  { text: 'Performance', href: '#performance' },
+  { text: 'Features', href: `${home}#features` },
+  { text: 'Architecture', href: `${home}#architecture` },
+  { text: 'Performance', href: `${home}#performance` },
   { text: 'Comparison', href: `${base}/comparison` },
-  { text: 'Quick Start', href: '#quickstart' },
+  { text: 'Quick Start', href: `${home}#quickstart` },
 ];
 
 const externalLinks = isZhCn ? [


### PR DESCRIPTION
## Bug

Reported: on a sub-page, clicking **Quick Start** does nothing, and afterward Architecture / Comparison / etc. also do nothing.

## Cause

The header nav used **relative hash links** (`#features`, `#architecture`, `#performance`, `#quickstart`) whose targets only exist on the **home page**. On a sub-page (`/comparison`, `/book`, zh-CN variants) clicking them resolved to e.g. `/comparison#quickstart` — a non-existent anchor — so the page didn't move. Reproduced headless: from `/comparison/`, all three section links gave `scrollY 0->0, targetOnThisPage=false`.

## Fix

Prefix the section anchors with the home path: `/#features` (EN) and `/zh-cn/#features` (zh). They now navigate to the home page and scroll to the section from anywhere. The Comparison full-page link is unchanged.

## Verification

Headless: from `/comparison/` and `/zh-cn/comparison/`, Quick Start / Architecture / Features now navigate home and scroll to the target; homepage behavior unchanged; all 6 pages still 0 console errors / failed requests / broken images; `astro build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)