### PR TITLE
fix(nav): correct deep #anchor landing after client components hydrate

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -59,5 +59,35 @@ const { title, description, ogImage } = Astro.props;
         mo.observe(document.body, { childList: true, subtree: true });
       })();
     </script>
+
+    <!-- Deep-anchor landing fix: client components (React-Flow diagrams)
+         hydrate and grow the page ~1900px after load, so an initial #hash
+         scroll lands short. Re-scroll to the target as the layout settles,
+         backing off the moment the user scrolls. -->
+    <script is:inline>
+      (function() {
+        if (!location.hash) return;
+        var id = decodeURIComponent(location.hash.slice(1));
+        if (!document.getElementById(id)) return;
+        var HEADER = 84; // matches scroll-padding-top
+        var interacted = false;
+        ['wheel','touchstart','keydown','pointerdown'].forEach(function(ev) {
+          window.addEventListener(ev, function() { interacted = true; }, { passive: true, once: true });
+        });
+        function jump() {
+          if (interacted) return;
+          var el = document.getElementById(id);
+          if (!el) return;
+          window.scrollTo(0, el.getBoundingClientRect().top + window.scrollY - HEADER);
+        }
+        // Follow the layout as it grows during hydration, then stop.
+        if (window.ResizeObserver) {
+          var ro = new ResizeObserver(jump);
+          ro.observe(document.body);
+          setTimeout(function() { ro.disconnect(); }, 3000);
+        }
+        window.addEventListener('load', jump);
+      })();
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Bug

Sometimes clicking **Quick Start** doesn't land on the Quick Start section — e.g. after going to Comparison, then Quick Start, you end up ~2000px short.

## Cause

The home page embeds **4 client-side React-Flow diagrams** that hydrate and **grow the page ~1900px after load**. On a deep-anchor load (e.g. /comparison -> /#quickstart), the browser scrolls to the target's parse-time position, then hydration pushes the section down — so you land short. It's a race, hence intermittent.

Measured: at DOMContentLoaded the page is 17711px; after hydration 19611px (+1900). The Quick Start heading ends up ~1984px below where the scroll stopped.

## Fix

Inline script: on load with a #hash, re-scroll to the target as the layout settles (`ResizeObserver` on body, capped at 3s), and **back off the instant the user scrolls / touches / keys / points** so it never yanks them. Offset matches the 84px `scroll-padding-top`.

## Verification (headless)

- `#quickstart` and `#architecture` both land at the 84px header offset after hydration (was ~2000px short).
- User wheel / keydown / pointerdown input is respected — no yank-back.
- All 6 pages still 0 console errors / failed requests / broken images; `astro build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)