### PR TITLE
feat: surface the Dora Hub on the website

### DIFF
--- a/src/data/book-chapters.json
+++ b/src/data/book-chapters.json
@@ -47,6 +47,17 @@
     ]
   },
   {
+    "section": "Node Packaging (Dora Hub)",
+    "chapters": [
+      { "title": "Overview", "description": "What the Hub is and the cargo-style package model", "href": "/book/hub/overview" },
+      { "title": "Using Hub Nodes", "description": "Reference, search, and inspect published nodes from a dataflow", "href": "/book/hub/using-nodes" },
+      { "title": "Writing a Node Manifest", "description": "Turn your code into a typed, versioned, reusable node", "href": "/book/hub/node-manifest" },
+      { "title": "Reproducible Builds", "description": "Lockfiles, --locked, checking for and applying updates, offline builds", "href": "/book/hub/reproducible-builds" },
+      { "title": "Publishing a Node", "description": "Publish to the catalog, manage versions, namespaces and ownership", "href": "/book/hub/publishing" },
+      { "title": "Custom & Enterprise Indexes", "description": "Private and mirrored catalogs, namespace binding, binary distribution", "href": "/book/hub/indexes" }
+    ]
+  },
+  {
     "section": "Development",
     "chapters": [
       { "title": "Testing Guide", "description": "Unit tests, integration tests, smoke tests, and TDD workflow", "href": "/book/development/testing" }

--- a/src/data/features.json
+++ b/src/data/features.json
@@ -18,6 +18,12 @@
     "statLabel": "languages"
   },
   {
+    "title": "Node Hub",
+    "description": "Pull a reusable node into a dataflow with one line — hub: dora-yolo@^0.5 — with cargo-style versioned resolution, reproducible lockfiles (--locked), and typed contracts checked at build time. Backed by a git-based public catalog of ready-made nodes.",
+    "stat": null,
+    "statLabel": null
+  },
+  {
     "title": "Fault Tolerance",
     "description": "Per-node restart policies (never/on-failure/always), exponential backoff, health monitoring, circuit breakers, and coordinator state persistence via redb.",
     "stat": null,

--- a/src/data/zh-cn/features.json
+++ b/src/data/zh-cn/features.json
@@ -18,6 +18,12 @@
     "statLabel": "种语言"
   },
   {
+    "title": "节点中心 (Node Hub)",
+    "description": "一行 YAML 即可将可复用节点引入数据流（hub: dora-yolo@^0.5）：cargo 风格的版本化解析、可复现的锁文件（--locked），以及构建时校验的类型契约。背后是一个基于 git 的公共节点目录。",
+    "stat": null,
+    "statLabel": null
+  },
+  {
     "title": "容错机制",
     "description": "按节点配置重启策略（never/on-failure/always）、指数退避、健康监控、熔断器、通过 redb 持久化协调器状态。",
     "stat": null,


### PR DESCRIPTION
The website had **no mention** of the Dora Hub (the node package manager). This adds it to the marketing site; the guide chapters themselves are served at `/book/hub/*` from the dora repo (dora-rs/dora#2260, already merged).

## Changes
- **`features.json` + `zh-cn/features.json`** — a **Node Hub** feature card (EN + 中文): pull a reusable node into a dataflow with one line (`hub: dora-yolo@^0.5`), cargo-style versioned resolution, reproducible lockfiles (`--locked`), and typed contracts checked at build time; backed by a git-based public catalog. (Both locales now have 11 cards.)
- **`book-chapters.json`** — a **Node Packaging (Dora Hub)** section linking the six guide chapters (Overview, Using Hub Nodes, Writing a Node Manifest, Reproducible Builds, Publishing a Node, Custom & Enterprise Indexes) under `/book/hub/*`, matching the guide SUMMARY. Shared by the EN and zh-CN book pages.

## Verification
- [x] JSON valid (all three files)
- [x] EN + zh feature counts match (11 each)
- [x] `npm run build` (Astro) passes
- [x] `/book/hub/*` links resolve once the guide deploys (its content merged in dora#2260)

Left for review: the copy + the rendered Node Hub card / book section. Not auto-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)